### PR TITLE
feat: add healthcheck in deployment k8s manifest

### DIFF
--- a/src/templates/deployment.yaml
+++ b/src/templates/deployment.yaml
@@ -45,3 +45,13 @@ spec:
           env:
             - name: EULA
               value: {{ .Values.eula | squote }}
+          livenessProbe:
+            exec:
+              command: ["mc-monitor", "status"]
+            periodSeconds: 1
+            failureThreshold: 5 # 5 seconds before considering the pod as unhealthy
+          startupProbe:
+            exec:
+              command: ["mc-monitor", "status"]
+            periodSeconds: 1
+            failureThreshold: 60 # 1 minute before considering the startup as failed


### PR DESCRIPTION
Add a healthcheck in containers
This way, when the server stops for any reason (like eula not accept or any crash), the container will restart by itself

The discussion about the efficiency of a readiness probe VS a startup probe took place in this old PR (in another repository, before the split): https://github.com/Djaytan/docker-papermc-server/pull/212