### PR TITLE
fix: define an unique identifier (#12)

### DIFF
--- a/src/values.schema.json
+++ b/src/values.schema.json
@@ -1,4 +1,5 @@
 {
+  "$id": "https://github.com/Djaytan/helm-papermc-server",
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "PaperMC-server Helm Chart Values Schema",
   "type": "object",


### PR DESCRIPTION
Added a unique identifier to the JSON Schema.

This fixes a missing best practice, I initially forgot to define a unique identifier, which should be included to ensure proper schema structure and validation. Considering this a fix.